### PR TITLE
전체음식 누적그래프 구현 완료

### DIFF
--- a/yolov5_django/templates/yolov5_django/_chart.html
+++ b/yolov5_django/templates/yolov5_django/_chart.html
@@ -69,26 +69,91 @@
   const classIndex = '{{ class_index }}'
   const labels = ['탄수화물', '단백질', '지방']
   
+  const numFoods = Object.keys(eachNutrition).length;
+  // 색상 알파값 동적 변경 함수
+  function generateAlphaValues(numFoods) {
+    const alphaValues = [];
+    for (let i = 0; i < numFoods; i++) {
+      const alpha = 0.2 + i * 0.1; 
+      alphaValues.push(alpha);
+    }
+    return alphaValues;
+  }
+
   //#
   let myChart
   // 리스트박스 선택값에 따라 그래프 업데이트하는 함수
   function updateChart(foodName) {
-    let nutrition
+    
+    let nutrition;
+
     if (foodName) {
       // 특정 음식 선택시 해당음식만
-      nutrition = eachNutrition[foodName]
+      nutrition = eachNutrition[foodName];
     } else {
       // 음식선택 X > 전체
-      nutrition = totalNutrition
+      nutrition = totalNutrition;
     }
+
     //#
-  
-    const dataKeys = ['carbohydrate', 'protein', 'fat']
-    const data = dataKeys.map((key) => nutrition[key])
-  
-    const sumOfTotalNutritions = data.reduce((a, b) => a + b, 0)
+    const dataKeys = ['carbohydrate', 'protein', 'fat'];
+    const dataD = dataKeys.map((key) => nutrition[key]);
+    const sumOfTotalNutritions = dataD.reduce((a, b) => a + b, 0);
   
     var graphType = document.querySelector('input[name = "graphType"]:checked').value;
+
+
+    const numFoods = Object.keys(eachNutrition).length;
+    const carbohydrateAlphas = generateAlphaValues(numFoods);
+    const proteinAlphas = generateAlphaValues(numFoods);
+    const fatAlphas = generateAlphaValues(numFoods);
+
+    // 전체 누적 막대그래프용
+    stackedDataset = Object.keys(eachNutrition).map((foodName, index) => ({
+      label: foodName,
+      data: [
+        eachNutrition[foodName].carbohydrate,
+        eachNutrition[foodName].fat,
+        eachNutrition[foodName].protein
+      ],
+      backgroundColor: [
+        `rgba(54, 162, 235, ${carbohydrateAlphas[index]})`,
+        `rgba(255, 99, 132, ${fatAlphas[index]})`,
+        `rgba(255, 205, 86, ${proteinAlphas[index]})`
+      ],
+      hoverOffset: 10
+    }));
+
+    // 개별 음식 막대그래프용
+    eachDataset = [
+    {
+      label: '',
+      data: dataD,
+      borderWidth: 1,
+      backgroundColor: [
+        'rgba(54, 162, 235, 0.5)',
+        'rgba(255, 99, 132, 0.5)',
+        'rgba(255, 205, 86, 0.5)'
+      ],
+      borderColor: [
+        'rgb(54, 162, 235)',
+        'rgb(255, 99, 132)',
+        'rgb(255, 205, 86)',
+      ],
+      hoverOffset: 10
+    }];
+
+    let customDataset;
+    let stackStatus;
+    if (foodName) {
+      // 특정 음식 선택시 해당음식만
+      customDataset = eachDataset;
+      stackStatus = false;
+    } else {
+      // 음식선택 X > 전체
+      customDataset = stackedDataset;
+      stackStatus = true;
+    }
 
     if (myChart) {
       // 리스트박스에서 새값 선택시 다시그리기위해 기존차트 지우기
@@ -102,7 +167,7 @@
         labels: labels,
         datasets: [
           {
-            data: data,
+            data: dataD,
             borderWidth: 1,
             backgroundColor: [
             'rgba(54, 162, 235, 0.5)',
@@ -139,48 +204,57 @@
     });
 
 // 파이그래프 끝
-
+    //막대그래프
   } else if (graphType ==='bar'){ 
     myChart = new Chart(ctx2, {
       type: 'bar',
       data: {
-        labels:labels,
-        datasets:[{
-          label:'3대 영양소',
-          data: data,
-          borderWidth: 1,
-          backgroundColor: [
-          'rgba(54, 162, 235, 0.5)',
-          'rgba(255, 99, 132, 0.5)',
-          'rgba(255, 205, 86, 0.5)'
-          ],
-          borderColor: [
-            'rgb(54, 162, 235)',
-            'rgb(255, 99, 132)',
-            'rgb(255, 205, 86)',
-          ],
-        }]
+        labels: labels,
+        datasets: customDataset,
       },
       options: {
           scales: {
               x: {
-                  stacked: true
+                  stacked: stackStatus,
               },
               y: {
-                  stacked: true
-              }
-          }
+                stacked: stackStatus,
+                beginAtZero: true, 
+                ticks: {
+                  callback: function(value, index, values) {
+                    return value + 'g'; 
+                  },
+                },
+              },
+          },
+          plugins: {
+            legend: {
+              display: false,
+            },
+            tooltip: {
+              callbacks: {
+                label: function(context) {
+                  console.log(context.dataset.label, context.formattedValue);
+                  const label = context.dataset.label || '';
+                  const value = context.dataset.data[context.dataIndex];
+                  return context.dataset.label + ': ' + context.formattedValue + 'g';
+                },
+              },
+            },
+          },
       }
   });
+  
   }
 }
 
   document.querySelector('form').addEventListener('change', function() {
-    // 라디오박스의 선택 값을 가져옴
+    // 라디오버튼의 선택 값을 가져옴
     updateChart();
   });
 
   document.getElementById('foodSelect').addEventListener('change', function() {
+    // 리스트박스의 선택값을 가져옴
     updateChart(this.value);
   });
 

--- a/yolov5_django/templates/yolov5_django/post.html
+++ b/yolov5_django/templates/yolov5_django/post.html
@@ -9,15 +9,6 @@
       <img src="{{ post.image.url }}" alt="{{ post.title }}" style="max-width:100%; max-height:640px;" />
       <p>작성일: {{ post.uploaded_at|date:'Y-m-d'  }}</p>
 
-      <p>
-        결과:{% if food_idx_list %}
-          {{ food_idx_list }}
-        {% else %}
-          없음
-        {% endif %}
-      </p>
-
-      <p>{{ food_name_list }}</p>
       <a href="{% url 'yolov5_django:my_page' %}">작성글 보기</a>
     </div>
 
@@ -26,10 +17,8 @@
       {% if food_idx_list and food_idx_list != "" %}
         {% include "yolov5_django/_chart.html" %}
       {% else %}
-        <p>.</p>
+        <p> </p>
       {% endif %}
-    </div>
-
-    
+    </div>    
   </div>
 {% endblock %}


### PR DESCRIPTION
---

이전내용 복붙 +  수정

---

### 사용자 파트

<이번 PR 내용>
- 음식사진 > 다량객체검출 > 누적 바그래프 생성
자바스크립트 문법을 모르니 진도가 더뎠지만 지금은 진짜최종파이널완성입니다

<진행중>

- index 페이지 템플릿 적용(테스트중)

<앞으로>

- 사용자가 "여기서 반만 먹었다, 1/3은 남겼다" > db의 영양소값에 적용(시도)

---

### 마이페이지 파트 

<진행중>

- 사진 업로드 시 사용자의 특정 사진 이름이 아닌 무작위글자로 저장되는 uuid4().hex함수 적용 (실습코드에있음)
- 게시물 업로드 당시의 시간이 아닌 사용자가 식사한 시간으로 직접 설정하여 업로드하도록 수정
ex) 2023년 9월 25일 13시 (분까지는 필요없을듯), 필터도 '연월일시'까지
 (가능하면 사진파일의 메타데이터 속 촬영시간을 읽어오면 좋을듯.. 어려우면 사용자직접지정으로 처리하고 패스)
- ** 게시물에 텍스트필드 추가. 간단한 일기작성용 **

<앞으로>

- 게시물 안에서도 삭제버튼
- (강사님 조언) 마이페이지 게시물에있는 수정/삭제 한줄로 정렬,  일반텍스트 하이퍼링크 > 버튼화
- 
---

### ★전체적인 마이페이지 구성요소 협의 및 업데이트 필요
- profile 페이지에서 입력받은 사용자 신체정보로 bmi, 연령에 따른 추천 탄단지비율, 열량 정보 제공 등

- 사진에서 검출된 객체의 영양 정보가 사용자 앞으로 저장되는 DB는 이미 구현되어있습니다. 마이페이지쪽에서 출력하면 됨

★ db넘어오지 않게 하는 명령어
``` 
git rm --cached db.sqlite3
git commit
```